### PR TITLE
Add checkbox to hide the suggestions bar.

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -289,6 +289,12 @@ export default class enhancedosk extends Extension {
             this.height = (monitor.height *
                            settings.get_int("portrait-height")) / 100;
           }
+
+          if (settings.get_boolean("show-suggestions")) {
+            this._suggestions?.show();
+          } else {
+            this._suggestions?.hide();
+          }
         }
       });
 

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -27,6 +27,8 @@ export default class MyExtensionPreferences extends ExtensionPreferences {
                                    ignoreTouch.active);
       window._settings.set_boolean("force-touch-input",
                                    forceTouch.active);
+      window._settings.set_boolean("show-suggestions",
+                                   showSuggestions.active);
 
 		});
 		group.add(apply)
@@ -106,6 +108,17 @@ export default class MyExtensionPreferences extends ExtensionPreferences {
 		row_forcetouch.add_suffix(forceTouch);
 		row_forcetouch.activatable_widget = forceTouch;
 
+    const row_showSuggestions = new Adw.ActionRow({
+			title: _('Show Suggestion bar')
+		});
+		group.add(row_showSuggestions);
 
+    const showSuggestions = new Gtk.Switch({
+			active: window._settings.get_boolean("show-suggestions"),
+			valign: Gtk.Align.CENTER,
+		});
+
+		row_showSuggestions.add_suffix(showSuggestions);
+		row_showSuggestions.activatable_widget = showSuggestions;
   }
 }

--- a/src/schemas/org.gnome.shell.extensions.enhancedosk.gschema.xml
+++ b/src/schemas/org.gnome.shell.extensions.enhancedosk.gschema.xml
@@ -15,6 +15,9 @@
     <key name="show-statusbar-icon" type="b">
       <default>false</default>
     </key>
+    <key name="show-suggestions" type="b">
+      <default>false</default>
+    </key>
     <key name="landscape-height" type="i">
       <default>33</default>
     </key>


### PR DESCRIPTION
Hey, thanks for updating this to gnome 45.

The suggestions bar was wasting precious real estate on my screen, took a while to figure out what element it was, but this PR hides it by default and introduces a checkbox to hide / show it.

With suggestions bar (original):
![Screenshot from 2023-12-17 21-13-21](https://github.com/cass00/enhanced-osk-gnome-ext/assets/1732289/f7fb0e6e-ab72-4894-891d-49457d7d0746)

Without suggestions bar:
![Screenshot from 2023-12-17 21-13-06](https://github.com/cass00/enhanced-osk-gnome-ext/assets/1732289/96736686-defb-4ff0-824d-58c0882a2ee6)

Just pointing it out, as you can see from the screenshots the layout in [my fork](https://github.com/iwanders/gnome-enhanced-osk-extension/tree/544584cec5f84058e5507133f326f20b9dfcde27#enhanced-osk-gnome-ext) is also modified, ensuring that row sizes don't change as shift / symbols are accessed. But this is the only change that's easy to contribute back as it is a simple imrovement.