### PR TITLE
Port extension to Gnome version 46

### DIFF
--- a/src/data/osk-layouts/am.json
+++ b/src/data/osk-layouts/am.json
@@ -1,7 +1,7 @@
 {
   "levels": [
     {
-      "level": "",
+      "level": "default",
       "mode": "default",
       "rows": [
         [
@@ -176,7 +176,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1,
+            "level": "shift",
             "width": 1.5
           },
           {
@@ -223,7 +223,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1,
+            "level": "shift",
             "width": 2
           }
         ],
@@ -231,7 +231,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -441,7 +441,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {
@@ -488,7 +488,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0,
+            "level": "default",
             "width": 2
           }
         ],
@@ -496,7 +496,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -679,7 +679,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 1.5
           },
           {
@@ -735,7 +735,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 3
           }
         ],
@@ -743,7 +743,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {
@@ -935,7 +935,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -976,7 +976,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 3
           }
         ],
@@ -984,7 +984,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {

--- a/src/data/osk-layouts/ara.json
+++ b/src/data/osk-layouts/ara.json
@@ -1,7 +1,7 @@
 {
   "levels": [
     {
-      "level": "",
+      "level": "default",
       "mode": "default",
       "rows": [
         [
@@ -207,7 +207,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -409,7 +409,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 1.5
           },
           {
@@ -463,7 +463,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 3
           }
         ],
@@ -471,7 +471,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {
@@ -666,7 +666,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -707,7 +707,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 3
           }
         ],
@@ -715,7 +715,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {

--- a/src/data/osk-layouts/at.json
+++ b/src/data/osk-layouts/at.json
@@ -1,7 +1,7 @@
 {
   "levels": [
     {
-      "level": "",
+      "level": "default",
       "mode": "default",
       "rows": [
         [
@@ -147,7 +147,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1
+            "level": "shift"
           },
           {
             "strings": [
@@ -208,7 +208,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1,
+            "level": "shift",
             "width": 1.5
           }
         ],
@@ -216,7 +216,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -390,7 +390,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0
+            "level": "default"
           },
           {
             "strings": [
@@ -451,7 +451,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           }
         ],
@@ -459,7 +459,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -635,7 +635,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 1.5
           },
           {
@@ -689,7 +689,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 3
           }
         ],
@@ -697,7 +697,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {
@@ -876,7 +876,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -917,7 +917,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 3
           }
         ],
@@ -925,7 +925,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {

--- a/src/data/osk-layouts/be.json
+++ b/src/data/osk-layouts/be.json
@@ -1,7 +1,7 @@
 {
   "levels": [
     {
-      "level": "",
+      "level": "default",
       "mode": "default",
       "rows": [
         [
@@ -162,7 +162,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1
+            "level": "shift"
           },
           {
             "strings": [
@@ -230,7 +230,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1,
+            "level": "shift",
             "width": 1.5
           }
         ],
@@ -238,7 +238,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -426,7 +426,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0
+            "level": "default"
           },
           {
             "strings": [
@@ -494,7 +494,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           }
         ],
@@ -502,7 +502,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -678,7 +678,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 1.5
           },
           {
@@ -732,7 +732,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 3
           }
         ],
@@ -740,7 +740,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {
@@ -919,7 +919,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -960,7 +960,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 3
           }
         ],
@@ -968,7 +968,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {

--- a/src/data/osk-layouts/bg.json
+++ b/src/data/osk-layouts/bg.json
@@ -1,7 +1,7 @@
 {
   "levels": [
     {
-      "level": "",
+      "level": "default",
       "mode": "default",
       "rows": [
         [
@@ -134,7 +134,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1
+            "level": "shift"
           },
           {
             "strings": [
@@ -198,7 +198,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1,
+            "level": "shift",
             "width": 1.5
           }
         ],
@@ -206,7 +206,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -367,7 +367,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {
@@ -414,7 +414,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0,
+            "level": "default",
             "width": 3
           }
         ],
@@ -422,7 +422,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -613,7 +613,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 1.5
           },
           {
@@ -667,7 +667,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 3
           }
         ],
@@ -675,7 +675,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {
@@ -853,7 +853,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -894,7 +894,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 3
           }
         ],
@@ -902,7 +902,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {

--- a/src/data/osk-layouts/by.json
+++ b/src/data/osk-layouts/by.json
@@ -1,7 +1,7 @@
 {
   "levels": [
     {
-      "level": "",
+      "level": "default",
       "mode": "default",
       "rows": [
         [
@@ -134,7 +134,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1,
+            "level": "shift",
             "width": 1.5
           },
           {
@@ -187,7 +187,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1,
+            "level": "shift",
             "width": 2
           }
         ],
@@ -195,7 +195,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -371,7 +371,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {
@@ -424,7 +424,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0,
+            "level": "default",
             "width": 2
           }
         ],
@@ -432,7 +432,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -623,7 +623,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 1.5
           },
           {
@@ -677,7 +677,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 3
           }
         ],
@@ -685,7 +685,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {
@@ -863,7 +863,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -904,7 +904,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 3
           }
         ],
@@ -912,7 +912,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {

--- a/src/data/osk-layouts/ca.json
+++ b/src/data/osk-layouts/ca.json
@@ -1,7 +1,7 @@
 {
   "levels": [
     {
-      "level": "",
+      "level": "default",
       "mode": "default",
       "rows": [
         [
@@ -161,7 +161,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1
+            "level": "shift"
           },
           {
             "strings": [
@@ -223,7 +223,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1,
+            "level": "shift",
             "width": 1.5
           }
         ],
@@ -231,7 +231,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -419,7 +419,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0
+            "level": "default"
           },
           {
             "strings": [
@@ -481,7 +481,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           }
         ],
@@ -489,7 +489,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -665,7 +665,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 1.5
           },
           {
@@ -719,7 +719,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 3
           }
         ],
@@ -727,7 +727,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {
@@ -905,7 +905,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -946,7 +946,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 3
           }
         ],
@@ -954,7 +954,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {

--- a/src/data/osk-layouts/ch+fr.json
+++ b/src/data/osk-layouts/ch+fr.json
@@ -1,7 +1,7 @@
 {
   "levels": [
     {
-      "level": "",
+      "level": "default",
       "mode": "default",
       "rows": [
         [
@@ -158,7 +158,7 @@
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
             "width": 1.5,
-            "level": 1
+            "level": "shift"
           },
           {
             "strings": [
@@ -224,7 +224,7 @@
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
             "width": 2,
-            "level": 1
+            "level": "shift"
           }
         ],
         [
@@ -236,7 +236,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2
+            "level": "opt"
           },
           {
             "action": "modifier",
@@ -442,7 +442,7 @@
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
             "width": 1.5,
-            "level": 0
+            "level": "default"
           },
           {
             "strings": [
@@ -507,7 +507,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0,
+            "level": "default",
             "width": 2
           }
         ],
@@ -520,7 +520,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2
+            "level": "opt"
           },
           {
             "action": "modifier",
@@ -717,7 +717,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 1.5
           },
           {
@@ -771,7 +771,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 3
           }
         ],
@@ -779,7 +779,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {
@@ -1008,7 +1008,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 2
           },
           {
@@ -1049,7 +1049,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 3
           }
         ],
@@ -1057,7 +1057,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 2
           },
           {

--- a/src/data/osk-layouts/ch.json
+++ b/src/data/osk-layouts/ch.json
@@ -1,7 +1,7 @@
 {
   "levels": [
     {
-      "level": "",
+      "level": "default",
       "mode": "default",
       "rows": [
         [
@@ -158,7 +158,7 @@
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
             "width": 1.5,
-            "level": 1
+            "level": "shift"
           },
           {
             "strings": [
@@ -224,7 +224,7 @@
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
             "width": 2,
-            "level": 1
+            "level": "shift"
           }
         ],
         [
@@ -236,7 +236,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2
+            "level": "opt"
           },
           {
             "action": "modifier",
@@ -442,7 +442,7 @@
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
             "width": 1.5,
-            "level": 0
+            "level": "default"
           },
           {
             "strings": [
@@ -507,7 +507,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0,
+            "level": "default",
             "width": 2
           }
         ],
@@ -520,7 +520,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2
+            "level": "opt"
           },
           {
             "action": "modifier",
@@ -717,7 +717,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 1.5
           },
           {
@@ -771,7 +771,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 3
           }
         ],
@@ -779,7 +779,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {
@@ -1008,7 +1008,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 2
           },
           {
@@ -1049,7 +1049,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 3
           }
         ],
@@ -1057,7 +1057,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 2
           },
           {

--- a/src/data/osk-layouts/cz.json
+++ b/src/data/osk-layouts/cz.json
@@ -1,7 +1,7 @@
 {
   "levels": [
     {
-      "level": "",
+      "level": "default",
       "mode": "default",
       "rows": [
         [
@@ -163,7 +163,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1
+            "level": "shift"
           },
           {
             "strings": [
@@ -230,7 +230,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1,
+            "level": "shift",
             "width": 1.5
           }
         ],
@@ -238,7 +238,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -428,7 +428,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0
+            "level": "default"
           },
           {
             "strings": [
@@ -495,7 +495,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           }
         ],
@@ -503,7 +503,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -679,7 +679,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 1.5
           },
           {
@@ -733,7 +733,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 3
           }
         ],
@@ -741,7 +741,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {
@@ -919,7 +919,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -960,7 +960,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 3
           }
         ],
@@ -968,7 +968,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {

--- a/src/data/osk-layouts/de.json
+++ b/src/data/osk-layouts/de.json
@@ -1,7 +1,7 @@
 {
   "levels": [
     {
-      "level": "",
+      "level": "default",
       "mode": "default",
       "rows": [
         [
@@ -158,7 +158,7 @@
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
             "width": 1.5,
-            "level": 1
+            "level": "shift"
           },
           {
             "strings": [
@@ -224,7 +224,7 @@
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
             "width": 2,
-            "level": 1
+            "level": "shift"
           }
         ],
         [
@@ -236,7 +236,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2
+            "level": "opt"
           },
           {
             "action": "modifier",
@@ -442,7 +442,7 @@
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
             "width": 1.5,
-            "level": 0
+            "level": "default"
           },
           {
             "strings": [
@@ -507,7 +507,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0,
+            "level": "default",
             "width": 2
           }
         ],
@@ -520,7 +520,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2
+            "level": "opt"
           },
           {
             "action": "modifier",
@@ -717,7 +717,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 1.5
           },
           {
@@ -771,7 +771,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 3
           }
         ],
@@ -779,7 +779,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {
@@ -1008,7 +1008,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 2
           },
           {
@@ -1049,7 +1049,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 3
           }
         ],
@@ -1057,7 +1057,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 2
           },
           {

--- a/src/data/osk-layouts/dk.json
+++ b/src/data/osk-layouts/dk.json
@@ -1,7 +1,7 @@
 {
   "levels": [
     {
-      "level": "",
+      "level": "default",
       "mode": "default",
       "rows": [
         [
@@ -163,7 +163,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1,
+            "level": "shift",
             "width": 1.5
           },
           {
@@ -225,7 +225,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1,
+            "level": "shift",
             "width": 2
           }
         ],
@@ -233,7 +233,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -423,7 +423,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {
@@ -485,7 +485,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0,
+            "level": "default",
             "width": 2
           }
         ],
@@ -493,7 +493,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -669,7 +669,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 1.5
           },
           {
@@ -723,7 +723,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 3
           }
         ],
@@ -731,7 +731,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {
@@ -910,7 +910,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -951,7 +951,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 3
           }
         ],
@@ -959,7 +959,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {

--- a/src/data/osk-layouts/ee.json
+++ b/src/data/osk-layouts/ee.json
@@ -1,7 +1,7 @@
 {
   "levels": [
     {
-      "level": "",
+      "level": "default",
       "mode": "default",
       "rows": [
         [
@@ -193,7 +193,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1,
+            "level": "shift",
             "width": 1.5
           },
           {
@@ -263,7 +263,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1,
+            "level": "shift",
             "width": 2
           }
         ],
@@ -271,7 +271,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -491,7 +491,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {
@@ -561,7 +561,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0,
+            "level": "default",
             "width": 2
           }
         ],
@@ -569,7 +569,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -745,7 +745,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 1.5
           },
           {
@@ -799,7 +799,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 3
           }
         ],
@@ -807,7 +807,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {
@@ -986,7 +986,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -1027,7 +1027,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 3
           }
         ],
@@ -1035,7 +1035,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {

--- a/src/data/osk-layouts/epo.json
+++ b/src/data/osk-layouts/epo.json
@@ -1,7 +1,7 @@
 {
   "levels": [
     {
-      "level": "",
+      "level": "default",
       "mode": "default",
       "rows": [
         [
@@ -206,7 +206,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1
+            "level": "shift"
           },
           {
             "strings": [
@@ -281,7 +281,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1,
+            "level": "shift",
             "width": 1.5
           }
         ],
@@ -289,7 +289,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -522,7 +522,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0
+            "level": "default"
           },
           {
             "strings": [
@@ -597,7 +597,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           }
         ],
@@ -605,7 +605,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -781,7 +781,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 1.5
           },
           {
@@ -835,7 +835,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 3
           }
         ],
@@ -843,7 +843,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {
@@ -1021,7 +1021,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -1062,7 +1062,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 3
           }
         ],
@@ -1070,7 +1070,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {

--- a/src/data/osk-layouts/es+cat.json
+++ b/src/data/osk-layouts/es+cat.json
@@ -1,7 +1,7 @@
 {
   "levels": [
     {
-      "level": "",
+      "level": "default",
       "mode": "default",
       "rows": [
         [
@@ -162,7 +162,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1
+            "level": "shift"
           },
           {
             "strings": [
@@ -225,7 +225,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1,
+            "level": "shift",
             "width": 1.5
           }
         ],
@@ -233,7 +233,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -422,7 +422,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0
+            "level": "default"
           },
           {
             "strings": [
@@ -485,7 +485,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           }
         ],
@@ -493,7 +493,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -669,7 +669,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 1.5
           },
           {
@@ -723,7 +723,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 3
           }
         ],
@@ -731,7 +731,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {
@@ -911,7 +911,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -952,7 +952,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 3
           }
         ],
@@ -960,7 +960,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {

--- a/src/data/osk-layouts/es.json
+++ b/src/data/osk-layouts/es.json
@@ -1,7 +1,7 @@
 {
   "levels": [
     {
-      "level": "",
+      "level": "default",
       "mode": "default",
       "rows": [
         [
@@ -171,7 +171,7 @@
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
             "width": 1.5,
-            "level": 1
+            "level": "shift"
           },
           {
             "strings": [
@@ -239,7 +239,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1,
+            "level": "shift",
             "width": 2
           }
         ],
@@ -252,7 +252,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2
+            "level": "opt"
           },
           {
             "action": "modifier",
@@ -471,7 +471,7 @@
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
             "width": 1.5,
-            "level": 0
+            "level": "default"
           },
           {
             "strings": [
@@ -539,7 +539,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0,
+            "level": "default",
             "width": 2
           }
         ],
@@ -552,7 +552,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2
+            "level": "opt"
           },
           {
             "action": "modifier",
@@ -749,7 +749,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 1.5
           },
           {
@@ -803,7 +803,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 3
           }
         ],
@@ -811,7 +811,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {
@@ -1043,7 +1043,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 2
           },
           {
@@ -1084,7 +1084,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 3
           }
         ],
@@ -1092,7 +1092,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 2
           },
           {

--- a/src/data/osk-layouts/fi.json
+++ b/src/data/osk-layouts/fi.json
@@ -1,7 +1,7 @@
 {
   "levels": [
     {
-      "level": "",
+      "level": "default",
       "mode": "default",
       "rows": [
         [
@@ -152,7 +152,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1,
+            "level": "shift",
             "width": 1.5
           },
           {
@@ -215,7 +215,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1,
+            "level": "shift",
             "width": 2
           }
         ],
@@ -223,7 +223,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -402,7 +402,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {
@@ -465,7 +465,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0,
+            "level": "default",
             "width": 2
           }
         ],
@@ -473,7 +473,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -649,7 +649,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 1.5
           },
           {
@@ -703,7 +703,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 3
           }
         ],
@@ -711,7 +711,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {
@@ -890,7 +890,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -931,7 +931,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 3
           }
         ],
@@ -939,7 +939,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {

--- a/src/data/osk-layouts/fr.json
+++ b/src/data/osk-layouts/fr.json
@@ -1,7 +1,7 @@
 {
   "levels": [
     {
-      "level": "",
+      "level": "default",
       "mode": "default",
       "rows": [
         [
@@ -177,7 +177,7 @@
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
             "width": 1.5,
-            "level": 1
+            "level": "shift"
           },
           {
             "strings": [
@@ -247,7 +247,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1,
+            "level": "shift",
             "width": 2
           }
         ],
@@ -260,7 +260,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2
+            "level": "opt"
           },
           {
             "action": "modifier",
@@ -485,7 +485,7 @@
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
             "width": 1.5,
-            "level": 0
+            "level": "default"
           },
           {
             "strings": [
@@ -555,7 +555,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0,
+            "level": "default",
             "width": 2
           }
         ],
@@ -568,7 +568,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2
+            "level": "opt"
           },
           {
             "action": "modifier",
@@ -765,7 +765,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 1.5
           },
           {
@@ -819,7 +819,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 3
           }
         ],
@@ -827,7 +827,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {
@@ -1056,7 +1056,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 2
           },
           {
@@ -1097,7 +1097,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 3
           }
         ],
@@ -1105,7 +1105,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 2
           },
           {

--- a/src/data/osk-layouts/ge.json
+++ b/src/data/osk-layouts/ge.json
@@ -1,7 +1,7 @@
 {
   "levels": [
     {
-      "level": "",
+      "level": "default",
       "mode": "default",
       "rows": [
         [
@@ -183,7 +183,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -359,7 +359,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 1.5
           },
           {
@@ -413,7 +413,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 3
           }
         ],
@@ -421,7 +421,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {
@@ -599,7 +599,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -640,7 +640,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 3
           }
         ],
@@ -648,7 +648,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {

--- a/src/data/osk-layouts/gr.json
+++ b/src/data/osk-layouts/gr.json
@@ -1,7 +1,7 @@
 {
   "levels": [
     {
-      "level": "",
+      "level": "default",
       "mode": "default",
       "rows": [
         [
@@ -129,7 +129,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1
+            "level": "shift"
           },
           {
             "strings": [
@@ -189,7 +189,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1,
+            "level": "shift",
             "width": 1.5
           }
         ],
@@ -197,7 +197,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -353,7 +353,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0
+            "level": "default"
           },
           {
             "strings": [
@@ -413,7 +413,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           }
         ],
@@ -421,7 +421,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -597,7 +597,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 1.5
           },
           {
@@ -651,7 +651,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 3
           }
         ],
@@ -659,7 +659,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {
@@ -838,7 +838,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -879,7 +879,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 3
           }
         ],
@@ -887,7 +887,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {

--- a/src/data/osk-layouts/hr.json
+++ b/src/data/osk-layouts/hr.json
@@ -1,7 +1,7 @@
 {
   "levels": [
     {
-      "level": "",
+      "level": "default",
       "mode": "default",
       "rows": [
         [
@@ -125,7 +125,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1
+            "level": "shift"
           },
           {
             "strings": [
@@ -189,7 +189,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1,
+            "level": "shift",
             "width": 1.5
           }
         ],
@@ -197,7 +197,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -349,7 +349,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0
+            "level": "default"
           },
           {
             "strings": [
@@ -413,7 +413,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           }
         ],
@@ -421,7 +421,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -597,7 +597,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 1.5
           },
           {
@@ -651,7 +651,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 3
           }
         ],
@@ -659,7 +659,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {
@@ -837,7 +837,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -878,7 +878,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 3
           }
         ],
@@ -886,7 +886,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {

--- a/src/data/osk-layouts/hu.json
+++ b/src/data/osk-layouts/hu.json
@@ -1,7 +1,7 @@
 {
   "levels": [
     {
-      "level": "",
+      "level": "default",
       "mode": "default",
       "rows": [
         [
@@ -164,7 +164,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1,
+            "level": "shift",
             "width": 1.5
           },
           {
@@ -228,7 +228,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1,
+            "level": "shift",
             "width": 2
           }
         ],
@@ -241,7 +241,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2
+            "level": "opt"
           },
           {
             "action": "modifier",
@@ -450,7 +450,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {
@@ -514,7 +514,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0,
+            "level": "default",
             "width": 2
           }
         ],
@@ -527,7 +527,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2
+            "level": "opt"
           },
           {
             "action": "modifier",
@@ -721,7 +721,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 1.5
           },
           {
@@ -775,7 +775,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 3
           }
         ],
@@ -783,7 +783,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {
@@ -1011,7 +1011,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 2
           },
           {
@@ -1052,7 +1052,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 3
           }
         ],
@@ -1060,7 +1060,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 2
           },
           {

--- a/src/data/osk-layouts/id.json
+++ b/src/data/osk-layouts/id.json
@@ -1,7 +1,7 @@
 {
   "levels": [
     {
-      "level": "",
+      "level": "default",
       "mode": "default",
       "rows": [
         [
@@ -118,7 +118,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1
+            "level": "shift"
           },
           {
             "strings": [
@@ -177,7 +177,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1,
+            "level": "shift",
             "width": 1.5
           }
         ],
@@ -185,7 +185,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -330,7 +330,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0
+            "level": "default"
           },
           {
             "strings": [
@@ -389,7 +389,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           }
         ],
@@ -397,7 +397,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -573,7 +573,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 1.5
           },
           {
@@ -627,7 +627,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 3
           }
         ],
@@ -635,7 +635,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {
@@ -813,7 +813,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -854,7 +854,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 3
           }
         ],
@@ -862,7 +862,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {

--- a/src/data/osk-layouts/il.json
+++ b/src/data/osk-layouts/il.json
@@ -1,7 +1,7 @@
 {
   "levels": [
     {
-      "level": "",
+      "level": "default",
       "mode": "default",
       "rows": [
         [
@@ -178,7 +178,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -371,7 +371,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 1.5
           },
           {
@@ -423,7 +423,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 3
           }
         ],
@@ -431,7 +431,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {
@@ -611,7 +611,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -652,7 +652,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 3
           }
         ],
@@ -660,7 +660,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {

--- a/src/data/osk-layouts/in+bolnagri.json
+++ b/src/data/osk-layouts/in+bolnagri.json
@@ -1,7 +1,7 @@
 {
   "levels": [
     {
-      "level": "",
+      "level": "default",
       "mode": "default",
       "rows": [
         [
@@ -221,7 +221,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -398,7 +398,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 1.5
           },
           {
@@ -452,7 +452,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 3
           }
         ],
@@ -460,7 +460,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {
@@ -639,7 +639,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -680,7 +680,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 3
           }
         ],
@@ -688,7 +688,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {

--- a/src/data/osk-layouts/in+mal.json
+++ b/src/data/osk-layouts/in+mal.json
@@ -1,7 +1,7 @@
 {
   "levels": [
     {
-      "level": "",
+      "level": "default",
       "mode": "default",
       "rows": [
         [
@@ -139,7 +139,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1,
+            "level": "shift",
             "width": 1
           },
           {
@@ -211,7 +211,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1,
+            "level": "shift",
             "width": 1.5
           }
         ],
@@ -219,7 +219,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -379,7 +379,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0
+            "level": "default"
           },
           {
             "strings": [
@@ -449,7 +449,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           }
         ],
@@ -457,7 +457,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -644,7 +644,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 1.5
           },
           {
@@ -698,7 +698,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 3
           }
         ],
@@ -706,7 +706,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {
@@ -884,7 +884,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -925,7 +925,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 3
           }
         ],
@@ -933,7 +933,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {

--- a/src/data/osk-layouts/ir.json
+++ b/src/data/osk-layouts/ir.json
@@ -1,7 +1,7 @@
 {
   "levels": [
     {
-      "level": "",
+      "level": "default",
       "mode": "default",
       "rows": [
         [
@@ -207,7 +207,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -412,7 +412,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 1.5
           },
           {
@@ -466,7 +466,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 3
           }
         ],
@@ -474,7 +474,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {
@@ -670,7 +670,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -711,7 +711,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 3
           }
         ],
@@ -719,7 +719,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {

--- a/src/data/osk-layouts/is.json
+++ b/src/data/osk-layouts/is.json
@@ -1,7 +1,7 @@
 {
   "levels": [
     {
-      "level": "",
+      "level": "default",
       "mode": "default",
       "rows": [
         [
@@ -156,7 +156,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1
+            "level": "shift"
           },
           {
             "strings": [
@@ -215,7 +215,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1,
+            "level": "shift",
             "width": 1.5
           }
         ],
@@ -223,7 +223,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -406,7 +406,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0
+            "level": "default"
           },
           {
             "strings": [
@@ -465,7 +465,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           }
         ],
@@ -473,7 +473,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -649,7 +649,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 1.5
           },
           {
@@ -703,7 +703,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 3
           }
         ],
@@ -711,7 +711,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {
@@ -889,7 +889,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -930,7 +930,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 3
           }
         ],
@@ -938,7 +938,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {

--- a/src/data/osk-layouts/it.json
+++ b/src/data/osk-layouts/it.json
@@ -1,7 +1,7 @@
 {
   "levels": [
     {
-      "level": "",
+      "level": "default",
       "mode": "default",
       "rows": [
         [
@@ -164,7 +164,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1,
+            "level": "shift",
             "width": 1.5
           },
           {
@@ -228,7 +228,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1,
+            "level": "shift",
             "width": 2
           }
         ],
@@ -241,7 +241,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2
+            "level": "opt"
           },
           {
             "action": "modifier",
@@ -450,7 +450,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {
@@ -514,7 +514,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0,
+            "level": "default",
             "width": 2
           }
         ],
@@ -527,7 +527,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2
+            "level": "opt"
           },
           {
             "action": "modifier",
@@ -721,7 +721,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 1.5
           },
           {
@@ -775,7 +775,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 3
           }
         ],
@@ -783,7 +783,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {
@@ -1012,7 +1012,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 2
           },
           {
@@ -1053,7 +1053,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 3
           }
         ],
@@ -1061,7 +1061,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 2
           },
           {

--- a/src/data/osk-layouts/ke.json
+++ b/src/data/osk-layouts/ke.json
@@ -1,7 +1,7 @@
 {
   "levels": [
     {
-      "level": "",
+      "level": "default",
       "mode": "default",
       "rows": [
         [
@@ -151,7 +151,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1
+            "level": "shift"
           },
           {
             "strings": [
@@ -212,7 +212,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1,
+            "level": "shift",
             "width": 1.5
           }
         ],
@@ -220,7 +220,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -398,7 +398,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0
+            "level": "default"
           },
           {
             "strings": [
@@ -459,7 +459,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           }
         ],
@@ -467,7 +467,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -643,7 +643,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 1.5
           },
           {
@@ -697,7 +697,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 3
           }
         ],
@@ -705,7 +705,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {
@@ -883,7 +883,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -924,7 +924,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 3
           }
         ],
@@ -932,7 +932,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {

--- a/src/data/osk-layouts/kg.json
+++ b/src/data/osk-layouts/kg.json
@@ -1,7 +1,7 @@
 {
   "levels": [
     {
-      "level": "",
+      "level": "default",
       "mode": "default",
       "rows": [
         [
@@ -137,7 +137,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1,
+            "level": "shift",
             "width": 1.5
           },
           {
@@ -190,7 +190,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1,
+            "level": "shift",
             "width": 2
           }
         ],
@@ -198,7 +198,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -377,7 +377,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {
@@ -430,7 +430,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0,
+            "level": "default",
             "width": 2
           }
         ],
@@ -438,7 +438,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -629,7 +629,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 1.5
           },
           {
@@ -683,7 +683,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 3
           }
         ],
@@ -691,7 +691,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {
@@ -869,7 +869,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -910,7 +910,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 3
           }
         ],
@@ -918,7 +918,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {

--- a/src/data/osk-layouts/kh.json
+++ b/src/data/osk-layouts/kh.json
@@ -1,7 +1,7 @@
 {
   "levels": [
     {
-      "level": "",
+      "level": "default",
       "mode": "default",
       "rows": [
         [
@@ -294,7 +294,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -471,7 +471,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 1.5
           },
           {
@@ -525,7 +525,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 3
           }
         ],
@@ -533,7 +533,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {
@@ -711,7 +711,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -752,7 +752,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 3
           }
         ],
@@ -760,7 +760,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {

--- a/src/data/osk-layouts/kr.json
+++ b/src/data/osk-layouts/kr.json
@@ -1,7 +1,7 @@
 {
   "levels": [
     {
-      "level": "",
+      "level": "default",
       "mode": "default",
       "rows": [
         [
@@ -198,7 +198,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -374,7 +374,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 1.5
           },
           {
@@ -428,7 +428,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 3
           }
         ],
@@ -436,7 +436,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {
@@ -614,7 +614,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -655,7 +655,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 3
           }
         ],
@@ -663,7 +663,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {

--- a/src/data/osk-layouts/la.json
+++ b/src/data/osk-layouts/la.json
@@ -1,7 +1,7 @@
 {
   "levels": [
     {
-      "level": "",
+      "level": "default",
       "mode": "default",
       "rows": [
         [
@@ -284,7 +284,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -461,7 +461,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 1.5
           },
           {
@@ -515,7 +515,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 3
           }
         ],
@@ -523,7 +523,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {
@@ -702,7 +702,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -743,7 +743,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 3
           }
         ],
@@ -751,7 +751,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {

--- a/src/data/osk-layouts/latam.json
+++ b/src/data/osk-layouts/latam.json
@@ -1,7 +1,7 @@
 {
   "levels": [
     {
-      "level": "",
+      "level": "default",
       "mode": "default",
       "rows": [
         [
@@ -160,7 +160,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1
+            "level": "shift"
           },
           {
             "strings": [
@@ -224,7 +224,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1,
+            "level": "shift",
             "width": 1.5
           }
         ],
@@ -232,7 +232,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -419,7 +419,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0
+            "level": "default"
           },
           {
             "strings": [
@@ -483,7 +483,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           }
         ],
@@ -491,7 +491,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -667,7 +667,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 1.5
           },
           {
@@ -721,7 +721,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 3
           }
         ],
@@ -729,7 +729,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {
@@ -910,7 +910,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -951,7 +951,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 3
           }
         ],
@@ -959,7 +959,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {

--- a/src/data/osk-layouts/lt.json
+++ b/src/data/osk-layouts/lt.json
@@ -1,7 +1,7 @@
 {
   "levels": [
     {
-      "level": "",
+      "level": "default",
       "mode": "default",
       "rows": [
         [
@@ -178,7 +178,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1
+            "level": "shift"
           },
           {
             "strings": [
@@ -247,7 +247,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1,
+            "level": "shift",
             "width": 1.5
           }
         ],
@@ -255,7 +255,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -460,7 +460,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0
+            "level": "default"
           },
           {
             "strings": [
@@ -529,7 +529,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           }
         ],
@@ -537,7 +537,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -713,7 +713,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 1.5
           },
           {
@@ -767,7 +767,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 3
           }
         ],
@@ -775,7 +775,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {
@@ -953,7 +953,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -994,7 +994,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 3
           }
         ],
@@ -1002,7 +1002,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {

--- a/src/data/osk-layouts/lv.json
+++ b/src/data/osk-layouts/lv.json
@@ -1,7 +1,7 @@
 {
   "levels": [
     {
-      "level": "",
+      "level": "default",
       "mode": "default",
       "rows": [
         [
@@ -177,7 +177,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1
+            "level": "shift"
           },
           {
             "strings": [
@@ -246,7 +246,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1,
+            "level": "shift",
             "width": 1.5
           }
         ],
@@ -254,7 +254,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -458,7 +458,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0
+            "level": "default"
           },
           {
             "strings": [
@@ -527,7 +527,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           }
         ],
@@ -535,7 +535,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -711,7 +711,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 1.5
           },
           {
@@ -765,7 +765,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 3
           }
         ],
@@ -773,7 +773,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {
@@ -951,7 +951,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -992,7 +992,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 3
           }
         ],
@@ -1000,7 +1000,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {

--- a/src/data/osk-layouts/mk.json
+++ b/src/data/osk-layouts/mk.json
@@ -1,7 +1,7 @@
 {
   "levels": [
     {
-      "level": "",
+      "level": "default",
       "mode": "default",
       "rows": [
         [
@@ -135,7 +135,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1,
+            "level": "shift",
             "width": 1.5
           },
           {
@@ -187,7 +187,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1,
+            "level": "shift",
             "width": 2
           }
         ],
@@ -195,7 +195,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -372,7 +372,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {
@@ -424,7 +424,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0,
+            "level": "default",
             "width": 2
           }
         ],
@@ -432,7 +432,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -623,7 +623,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 1.5
           },
           {
@@ -677,7 +677,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 3
           }
         ],
@@ -685,7 +685,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {
@@ -863,7 +863,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -904,7 +904,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 3
           }
         ],
@@ -912,7 +912,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {

--- a/src/data/osk-layouts/mn.json
+++ b/src/data/osk-layouts/mn.json
@@ -1,7 +1,7 @@
 {
   "levels": [
     {
-      "level": "",
+      "level": "default",
       "mode": "default",
       "rows": [
         [
@@ -134,7 +134,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1,
+            "level": "shift",
             "width": 1.5
           },
           {
@@ -189,7 +189,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1,
+            "level": "shift",
             "width": 2
           }
         ],
@@ -197,7 +197,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -373,7 +373,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {
@@ -428,7 +428,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0,
+            "level": "default",
             "width": 2
           }
         ],
@@ -436,7 +436,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -628,7 +628,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 1.5
           },
           {
@@ -682,7 +682,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 3
           }
         ],
@@ -690,7 +690,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {
@@ -869,7 +869,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -910,7 +910,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 3
           }
         ],
@@ -918,7 +918,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {

--- a/src/data/osk-layouts/my.json
+++ b/src/data/osk-layouts/my.json
@@ -1,7 +1,7 @@
 {
   "levels": [
     {
-      "level": "",
+      "level": "default",
       "mode": "default",
       "rows": [
         [
@@ -118,7 +118,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1
+            "level": "shift"
           },
           {
             "strings": [
@@ -177,7 +177,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1,
+            "level": "shift",
             "width": 1.5
           }
         ],
@@ -185,7 +185,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -330,7 +330,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0
+            "level": "default"
           },
           {
             "strings": [
@@ -389,7 +389,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           }
         ],
@@ -397,7 +397,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -573,7 +573,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 1.5
           },
           {
@@ -627,7 +627,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 3
           }
         ],
@@ -635,7 +635,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {
@@ -813,7 +813,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -854,7 +854,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 3
           }
         ],
@@ -862,7 +862,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {

--- a/src/data/osk-layouts/nl.json
+++ b/src/data/osk-layouts/nl.json
@@ -1,7 +1,7 @@
 {
   "levels": [
     {
-      "level": "",
+      "level": "default",
       "mode": "default",
       "rows": [
         [
@@ -154,7 +154,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1
+            "level": "shift"
           },
           {
             "strings": [
@@ -215,7 +215,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1,
+            "level": "shift",
             "width": 1.5
           }
         ],
@@ -223,7 +223,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -404,7 +404,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0
+            "level": "default"
           },
           {
             "strings": [
@@ -465,7 +465,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           }
         ],
@@ -473,7 +473,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -649,7 +649,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 1.5
           },
           {
@@ -703,7 +703,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 3
           }
         ],
@@ -711,7 +711,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {
@@ -890,7 +890,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -931,7 +931,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 3
           }
         ],
@@ -939,7 +939,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {

--- a/src/data/osk-layouts/no.json
+++ b/src/data/osk-layouts/no.json
@@ -1,7 +1,7 @@
 {
   "levels": [
     {
-      "level": "",
+      "level": "default",
       "mode": "default",
       "rows": [
         [
@@ -163,7 +163,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1,
+            "level": "shift",
             "width": 1.5
           },
           {
@@ -225,7 +225,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1,
+            "level": "shift",
             "width": 2
           }
         ],
@@ -233,7 +233,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -423,7 +423,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {
@@ -485,7 +485,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0,
+            "level": "default",
             "width": 2
           }
         ],
@@ -493,7 +493,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -669,7 +669,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 1.5
           },
           {
@@ -723,7 +723,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 3
           }
         ],
@@ -731,7 +731,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {
@@ -910,7 +910,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -951,7 +951,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 3
           }
         ],
@@ -959,7 +959,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {

--- a/src/data/osk-layouts/ph.json
+++ b/src/data/osk-layouts/ph.json
@@ -1,7 +1,7 @@
 {
   "levels": [
     {
-      "level": "",
+      "level": "default",
       "mode": "default",
       "rows": [
         [
@@ -118,7 +118,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1
+            "level": "shift"
           },
           {
             "strings": [
@@ -177,7 +177,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1,
+            "level": "shift",
             "width": 1.5
           }
         ],
@@ -185,7 +185,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -330,7 +330,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0
+            "level": "default"
           },
           {
             "strings": [
@@ -389,7 +389,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           }
         ],
@@ -397,7 +397,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -573,7 +573,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 1.5
           },
           {
@@ -627,7 +627,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 3
           }
         ],
@@ -635,7 +635,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {
@@ -813,7 +813,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -854,7 +854,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 3
           }
         ],
@@ -862,7 +862,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {

--- a/src/data/osk-layouts/pl.json
+++ b/src/data/osk-layouts/pl.json
@@ -1,7 +1,7 @@
 {
   "levels": [
     {
-      "level": "",
+      "level": "default",
       "mode": "default",
       "rows": [
         [
@@ -156,7 +156,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1,
+            "level": "shift",
             "width": 2
           },
           {
@@ -224,7 +224,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1,
+            "level": "shift",
             "width": 2
           }
         ],
@@ -237,7 +237,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2
+            "level": "opt"
           },
           {
             "action": "modifier",
@@ -438,7 +438,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0,
+            "level": "default",
             "width": 2
           },
           {
@@ -506,7 +506,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0,
+            "level": "default",
             "width": 2
           }
         ],
@@ -519,7 +519,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2
+            "level": "opt"
           },
           {
             "action": "modifier",
@@ -713,7 +713,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 1.5
           },
           {
@@ -767,7 +767,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 3
           }
         ],
@@ -775,7 +775,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {
@@ -1003,7 +1003,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 2
           },
           {
@@ -1044,7 +1044,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 3
           }
         ],
@@ -1052,7 +1052,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 2
           },
           {

--- a/src/data/osk-layouts/pt.json
+++ b/src/data/osk-layouts/pt.json
@@ -1,7 +1,7 @@
 {
   "levels": [
     {
-      "level": "",
+      "level": "default",
       "mode": "default",
       "rows": [
         [
@@ -153,7 +153,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1
+            "level": "shift"
           },
           {
             "strings": [
@@ -215,7 +215,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1,
+            "level": "shift",
             "width": 1.5
           }
         ],
@@ -223,7 +223,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -403,7 +403,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0
+            "level": "default"
           },
           {
             "strings": [
@@ -465,7 +465,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           }
         ],
@@ -473,7 +473,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -649,7 +649,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 1.5
           },
           {
@@ -703,7 +703,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 3
           }
         ],
@@ -711,7 +711,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {
@@ -890,7 +890,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -931,7 +931,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 3
           }
         ],
@@ -939,7 +939,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {

--- a/src/data/osk-layouts/ro.json
+++ b/src/data/osk-layouts/ro.json
@@ -1,7 +1,7 @@
 {
   "levels": [
     {
-      "level": "",
+      "level": "default",
       "mode": "default",
       "rows": [
         [
@@ -138,7 +138,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1
+            "level": "shift"
           },
           {
             "strings": [
@@ -197,7 +197,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1,
+            "level": "shift",
             "width": 1.5
           }
         ],
@@ -205,7 +205,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -370,7 +370,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0
+            "level": "default"
           },
           {
             "strings": [
@@ -429,7 +429,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           }
         ],
@@ -437,7 +437,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -613,7 +613,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 1.5
           },
           {
@@ -667,7 +667,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 3
           }
         ],
@@ -675,7 +675,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {
@@ -853,7 +853,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -894,7 +894,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 3
           }
         ],
@@ -902,7 +902,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {

--- a/src/data/osk-layouts/rs.json
+++ b/src/data/osk-layouts/rs.json
@@ -1,7 +1,7 @@
 {
   "levels": [
     {
-      "level": "",
+      "level": "default",
       "mode": "default",
       "rows": [
         [
@@ -135,7 +135,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1,
+            "level": "shift",
             "width": 1.5
           },
           {
@@ -187,7 +187,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1,
+            "level": "shift",
             "width": 2
           }
         ],
@@ -195,7 +195,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -372,7 +372,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {
@@ -424,7 +424,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0,
+            "level": "default",
             "width": 2
           }
         ],
@@ -432,7 +432,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -623,7 +623,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 1.5
           },
           {
@@ -677,7 +677,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 3
           }
         ],
@@ -685,7 +685,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {
@@ -863,7 +863,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -904,7 +904,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 3
           }
         ],
@@ -912,7 +912,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {

--- a/src/data/osk-layouts/ru.json
+++ b/src/data/osk-layouts/ru.json
@@ -1,7 +1,7 @@
 {
   "levels": [
     {
-      "level": "",
+      "level": "default",
       "mode": "default",
       "rows": [
         [
@@ -144,7 +144,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1,
+            "level": "shift",
             "width": 2
           },
           {
@@ -201,7 +201,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1,
+            "level": "shift",
             "width": 2
           }
         ],
@@ -214,7 +214,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2
+            "level": "opt"
           },
           {
             "action": "modifier",
@@ -416,7 +416,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0,
+            "level": "default",
             "width": 2
           },
           {
@@ -473,7 +473,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0,
+            "level": "default",
             "width": 2
           }
         ],
@@ -486,7 +486,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2
+            "level": "opt"
           },
           {
             "action": "modifier",
@@ -693,7 +693,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 1.5
           },
           {
@@ -747,7 +747,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 3
           }
         ],
@@ -755,7 +755,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {
@@ -983,7 +983,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 2
           },
           {
@@ -1024,7 +1024,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 3
           }
         ],
@@ -1032,7 +1032,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 2
           },
           {

--- a/src/data/osk-layouts/se.json
+++ b/src/data/osk-layouts/se.json
@@ -1,7 +1,7 @@
 {
   "levels": [
     {
-      "level": "",
+      "level": "default",
       "mode": "default",
       "rows": [
         [
@@ -173,7 +173,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1,
+            "level": "shift",
             "width": 1.5
           },
           {
@@ -242,7 +242,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1,
+            "level": "shift",
             "width": 2
           }
         ],
@@ -250,7 +250,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -450,7 +450,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {
@@ -519,7 +519,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0,
+            "level": "default",
             "width": 2
           }
         ],
@@ -527,7 +527,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -703,7 +703,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 1.5
           },
           {
@@ -757,7 +757,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 3
           }
         ],
@@ -765,7 +765,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {
@@ -944,7 +944,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -985,7 +985,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 3
           }
         ],
@@ -993,7 +993,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {

--- a/src/data/osk-layouts/si.json
+++ b/src/data/osk-layouts/si.json
@@ -1,7 +1,7 @@
 {
   "levels": [
     {
-      "level": "",
+      "level": "default",
       "mode": "default",
       "rows": [
         [
@@ -120,7 +120,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1
+            "level": "shift"
           },
           {
             "strings": [
@@ -182,7 +182,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1,
+            "level": "shift",
             "width": 1.5
           }
         ],
@@ -190,7 +190,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -337,7 +337,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0
+            "level": "default"
           },
           {
             "strings": [
@@ -399,7 +399,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           }
         ],
@@ -407,7 +407,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -583,7 +583,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 1.5
           },
           {
@@ -637,7 +637,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 3
           }
         ],
@@ -645,7 +645,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {
@@ -824,7 +824,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -865,7 +865,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 3
           }
         ],
@@ -873,7 +873,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {

--- a/src/data/osk-layouts/sk.json
+++ b/src/data/osk-layouts/sk.json
@@ -1,7 +1,7 @@
 {
   "levels": [
     {
-      "level": "",
+      "level": "default",
       "mode": "default",
       "rows": [
         [
@@ -177,7 +177,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1
+            "level": "shift"
           },
           {
             "strings": [
@@ -247,7 +247,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1,
+            "level": "shift",
             "width": 1.5
           }
         ],
@@ -255,7 +255,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -459,7 +459,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0
+            "level": "default"
           },
           {
             "strings": [
@@ -529,7 +529,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           }
         ],
@@ -537,7 +537,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -713,7 +713,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 1.5
           },
           {
@@ -767,7 +767,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 3
           }
         ],
@@ -775,7 +775,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {
@@ -954,7 +954,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -995,7 +995,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 3
           }
         ],
@@ -1003,7 +1003,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {

--- a/src/data/osk-layouts/th.json
+++ b/src/data/osk-layouts/th.json
@@ -1,7 +1,7 @@
 {
   "levels": [
     {
-      "level": "",
+      "level": "default",
       "mode": "default",
       "rows": [
         [
@@ -215,7 +215,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1,
+            "level": "shift",
             "width": 1.5
           },
           {
@@ -272,7 +272,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1,
+            "level": "shift",
             "width": 2
           }
         ],
@@ -280,7 +280,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -531,7 +531,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {
@@ -588,7 +588,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0,
+            "level": "default",
             "width": 2
           }
         ],
@@ -596,7 +596,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -792,7 +792,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 1.5
           },
           {
@@ -846,7 +846,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 3
           }
         ],
@@ -854,7 +854,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {
@@ -1033,7 +1033,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -1074,7 +1074,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 3
           }
         ],
@@ -1082,7 +1082,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {

--- a/src/data/osk-layouts/tr.json
+++ b/src/data/osk-layouts/tr.json
@@ -1,7 +1,7 @@
 {
   "levels": [
     {
-      "level": "",
+      "level": "default",
       "mode": "default",
       "rows": [
         [
@@ -144,7 +144,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1
+            "level": "shift"
           },
           {
             "strings": [
@@ -206,7 +206,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1,
+            "level": "shift",
             "width": 1.5
           }
         ],
@@ -214,7 +214,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -385,7 +385,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0
+            "level": "default"
           },
           {
             "strings": [
@@ -447,7 +447,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           }
         ],
@@ -455,7 +455,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -631,7 +631,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 1.5
           },
           {
@@ -685,7 +685,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 3
           }
         ],
@@ -693,7 +693,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {
@@ -872,7 +872,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -913,7 +913,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 3
           }
         ],
@@ -921,7 +921,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {

--- a/src/data/osk-layouts/ua.json
+++ b/src/data/osk-layouts/ua.json
@@ -1,7 +1,7 @@
 {
   "levels": [
     {
-      "level": "",
+      "level": "default",
       "mode": "default",
       "rows": [
         [
@@ -145,7 +145,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1,
+            "level": "shift",
             "width": 2
           },
           {
@@ -202,7 +202,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1,
+            "level": "shift",
             "width": 2
           }
         ],
@@ -215,7 +215,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2
+            "level": "opt"
           },
           {
             "action": "modifier",
@@ -418,7 +418,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0,
+            "level": "default",
             "width": 2
           },
           {
@@ -475,7 +475,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0,
+            "level": "default",
             "width": 2
           }
         ],
@@ -488,7 +488,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2
+            "level": "opt"
           },
           {
             "action": "modifier",
@@ -696,7 +696,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 1.5
           },
           {
@@ -750,7 +750,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 3
           }
         ],
@@ -758,7 +758,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {
@@ -987,7 +987,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 2
           },
           {
@@ -1028,7 +1028,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 3
           }
         ],
@@ -1036,7 +1036,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 2
           },
           {

--- a/src/data/osk-layouts/uk.json
+++ b/src/data/osk-layouts/uk.json
@@ -1,7 +1,7 @@
 {
   "levels": [
     {
-      "level": "",
+      "level": "default",
       "mode": "default",
       "rows": [
         [
@@ -150,7 +150,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1
+            "level": "shift"
           },
           {
             "strings": [
@@ -211,7 +211,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1,
+            "level": "shift",
             "width": 1.5
           }
         ],
@@ -219,7 +219,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -396,7 +396,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0
+            "level": "default"
           },
           {
             "strings": [
@@ -457,7 +457,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           }
         ],
@@ -465,7 +465,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -641,7 +641,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 1.5
           },
           {
@@ -695,7 +695,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 3
           }
         ],
@@ -703,7 +703,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {
@@ -882,7 +882,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -923,7 +923,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 3
           }
         ],
@@ -931,7 +931,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {

--- a/src/data/osk-layouts/us-extended.json
+++ b/src/data/osk-layouts/us-extended.json
@@ -1,7 +1,7 @@
 {
   "levels": [
     {
-      "level": "",
+      "level": "default",
       "mode": "default",
       "rows": [
         [
@@ -160,7 +160,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1,
+            "level": "shift",
             "width": 2
           },
           {
@@ -222,7 +222,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1,
+            "level": "shift",
             "width": 2
           }
         ],
@@ -235,7 +235,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2
+            "level": "opt"
           },
           {
             "action": "modifier",
@@ -435,7 +435,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0,
+            "level": "default",
             "width": 2
           },
           {
@@ -497,7 +497,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0,
+            "level": "default",
             "width": 2
           }
         ],
@@ -510,7 +510,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2
+            "level": "opt"
           },
           {
             "action": "modifier",
@@ -699,7 +699,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 1.5
           },
           {
@@ -753,7 +753,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 3
           }
         ],
@@ -761,7 +761,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {
@@ -989,7 +989,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 2
           },
           {
@@ -1030,7 +1030,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 3
           }
         ],
@@ -1038,7 +1038,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 2
           },
           {

--- a/src/data/osk-layouts/us.json
+++ b/src/data/osk-layouts/us.json
@@ -1,7 +1,7 @@
 {
   "levels": [
     {
-      "level": "",
+      "level": "default",
       "mode": "default",
       "rows": [
         [
@@ -160,7 +160,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1,
+            "level": "shift",
             "width": 2
           },
           {
@@ -222,7 +222,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1,
+            "level": "shift",
             "width": 2
           }
         ],
@@ -235,7 +235,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2
+            "level": "opt"
           },
           {
             "action": "modifier",
@@ -440,7 +440,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0,
+            "level": "default",
             "width": 2
           },
           {
@@ -502,7 +502,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0,
+            "level": "default",
             "width": 2
           }
         ],
@@ -515,7 +515,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2
+            "level": "opt"
           },
           {
             "action": "modifier",
@@ -709,7 +709,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 1.5
           },
           {
@@ -763,7 +763,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 3
           }
         ],
@@ -771,7 +771,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {
@@ -999,7 +999,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 2
           },
           {
@@ -1040,7 +1040,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 3
           }
         ],
@@ -1048,7 +1048,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 2
           },
           {

--- a/src/data/osk-layouts/vn.json
+++ b/src/data/osk-layouts/vn.json
@@ -1,7 +1,7 @@
 {
   "levels": [
     {
-      "level": "",
+      "level": "default",
       "mode": "default",
       "rows": [
         [
@@ -185,7 +185,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1
+            "level": "shift"
           },
           {
             "strings": [
@@ -244,7 +244,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1,
+            "level": "shift",
             "width": 1.5
           }
         ],
@@ -252,7 +252,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -464,7 +464,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0
+            "level": "default"
           },
           {
             "strings": [
@@ -523,7 +523,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           }
         ],
@@ -531,7 +531,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -708,7 +708,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 1.5
           },
           {
@@ -762,7 +762,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 3
           }
         ],
@@ -770,7 +770,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {
@@ -949,7 +949,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -990,7 +990,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 3
           }
         ],
@@ -998,7 +998,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {

--- a/src/data/osk-layouts/za.json
+++ b/src/data/osk-layouts/za.json
@@ -1,7 +1,7 @@
 {
   "levels": [
     {
-      "level": "",
+      "level": "default",
       "mode": "default",
       "rows": [
         [
@@ -157,7 +157,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1
+            "level": "shift"
           },
           {
             "strings": [
@@ -218,7 +218,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 1,
+            "level": "shift",
             "width": 1.5
           }
         ],
@@ -226,7 +226,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -410,7 +410,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0
+            "level": "default"
           },
           {
             "strings": [
@@ -471,7 +471,7 @@
             "action": "modifier",
             "keyval": "0xffe1",
             "iconName": "keyboard-shift-symbolic",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           }
         ],
@@ -479,7 +479,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -655,7 +655,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 1.5
           },
           {
@@ -709,7 +709,7 @@
           {
             "action": "levelSwitch",
             "label": "=/<",
-            "level": 3,
+            "level": "opt+shift",
             "width": 3
           }
         ],
@@ -717,7 +717,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {
@@ -895,7 +895,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 1.5
           },
           {
@@ -936,7 +936,7 @@
           {
             "action": "levelSwitch",
             "label": "?123",
-            "level": 2,
+            "level": "opt",
             "width": 3
           }
         ],
@@ -944,7 +944,7 @@
           {
             "action": "levelSwitch",
             "label": "ABC",
-            "level": 0,
+            "level": "default",
             "width": 1.5
           },
           {

--- a/src/extension.js
+++ b/src/extension.js
@@ -4,54 +4,18 @@ import GLib from 'gi://GLib';
 import St from 'gi://St';
 import Clutter from 'gi://Clutter';
 import GObject from 'gi://GObject';
-import {Extension, InjectionManager} from 'resource:///org/gnome/shell/extensions/extension.js';
+import { Extension, InjectionManager } from 'resource:///org/gnome/shell/extensions/extension.js';
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 import * as Keyboard from 'resource:///org/gnome/shell/ui/keyboard.js';
 import * as PanelMenu from 'resource:///org/gnome/shell/ui/panelMenu.js';
 
 const A11Y_APPLICATIONS_SCHEMA = "org.gnome.desktop.a11y.applications";
-const KEY_RELEASE_TIMEOUT = 100;
 
 
 //check how to get metadata
 
 let settings;
 let keyReleaseTimeoutId;
-
-//Model class for _addrowKeys emulation
-class KeyboardModel {
-  constructor(groupName) {
-    let names = [groupName];
-    if (groupName.includes('+'))
-      names.push(groupName.replace(/\+.*/, ''));
-    names.push('us');
-
-    for (let i = 0; i < names.length; i++) {
-      try {
-        this._model = this._loadModel(names[i]);
-        break;
-      } catch (e) {
-      }
-    }
-  }
-
-  _loadModel(groupName) {
-    const file = Gio.File.new_for_uri(
-      `resource:///org/gnome/shell/osk-layouts/${groupName}.json`);
-    let [success_, contents] = file.load_contents(null);
-
-    const decoder = new TextDecoder();
-    return JSON.parse(decoder.decode(contents));
-  }
-
-  getLevels() {
-    return this._model.levels;
-  }
-
-  getKeysForLevel(levelName) {
-    return this._model.levels.find(level => level === levelName);
-  }
-}
 
 // Indicator
 let OSKIndicator = GObject.registerClass(
@@ -87,9 +51,7 @@ let OSKIndicator = GObject.registerClass(
 );
 
 function toggleOSK() {
-  //Main.keyboard._keyboard._keyboardController.destroy();
-  //Main.keyboard._keyboard._setupKeyboard();
-  if (Main.keyboard._keyboard !== null ){
+  if (Main.keyboard._keyboard !== null) {
     if (Main.keyboard._keyboard._keyboardVisible) return Main.keyboard.close();
     Main.keyboard.open(Main.layoutManager.bottomIndex);
   }
@@ -103,72 +65,12 @@ function override_getCurrentGroup() {
     let prop;
     for (let i = 0; (prop = currentSource.properties.get(i)) !== null; ++i) {
       if (prop.get_key() === 'InputMode' &&
-          prop.get_prop_type() === IBus.PropType.TOGGLE &&
-          prop.get_state() !== IBus.PropState.CHECKED)
+        prop.get_prop_type() === IBus.PropType.TOGGLE &&
+        prop.get_state() !== IBus.PropState.CHECKED)
         return 'us';
     }
   }
   return this._currentSource.xkbId;
-}
-
-function addition_createLayersforGroup(ref_this,groupName) {
-  //console.log("osk: JS ERROR Running addition_create");
-  //Idea: emulate _createLayersForGroup
-  //copy over KeyboardModel class to here as extra class (not complex)
-  //shiftKeys needs to be repopulated
-  //loadRows directly in
-  //check appendRow
-  //then comes _addRowKeys
-  //there instead of creating new button we load button from layout
-  // then we disconnect button
-  // then run all the rest of  wthe overwrite function
-  // without appendKey function
-
-  //Note: This is all necessary because Key class in keyboard.js is not exported
-  //if exported then the original override_addRowKeys can be used
-
-  //a is layers array that contains all layouts
-  //let a =  ref_this._groups[ref_this._keyboardController.getCurrentGroup()];
-  //a[n] is nth layout; then _rows[n] nth row;
-  //keys[n] nth keyInfo (check appendKey function;
-  //.key gives you then the key class
-  //let b = a[0]._rows[0].keys[0].key
-  //b.disconnect()
-  //b.connect('released', () => {ref_this.close();});
-  let keyboardModel = new KeyboardModel(groupName);
-  let layers = ref_this._groups[ref_this._keyboardController.getCurrentGroup()];
-  let levels = keyboardModel.getLevels();
-  for (let i = 0; i < levels.length; i++) {
-  //for (let i = 0; i < 0; i++) {
-    let currentLevel = levels[i];
-    let level = i >= 1 && levels.length === 3 ? i + 1 : i;
-    let layout = layers[level]
-    layout.shiftKeys = [];
-    layout.mode = currentLevel.mode;
-    //this._loadRows(currentLevel, level, levels.length, layout);
-    //_loadRows(model, level, numLevels, layout) {
-    let rows = currentLevel.rows;
-    for (let j = 0; j < rows.length; ++j) {
-      override_addRowKeys(ref_this,rows[j], layout,j);
-    }
-    layout.hide();
-  }
-}
-
-function override_addRowKeys(ref_this, keys, layout,index_row) {
-  for (let i = 0; i < keys.length; ++i) {
-    const key = keys[i];
-    let button = layout._rows[index_row].keys[i].key
-
-    if (key.iconName === 'keyboard-shift-symbolic'){
-      layout.shiftKeys.push(button);
-      button.connect('long-press', () => {
-        ref_this._setActiveLayer(1);
-        ref_this._setLatched(true);
-        ref_this._iscapslock = true;
-      });
-    }
-  }
 }
 
 // Extension
@@ -265,26 +167,26 @@ export default class enhancedosk extends Extension {
 
   getModifiedLayouts() {
     const modifiedLayoutsPath = this.dir
-          .get_child("data")
-          .get_child("gnome-shell-osk-layouts.gresource")
-          .get_path();
+      .get_child("data")
+      .get_child("gnome-shell-osk-layouts.gresource")
+      .get_path();
     return Gio.Resource.load(modifiedLayoutsPath);
   }
 
   enable_overrides() {
     this._injectionManager.overrideMethod(
       Keyboard.Keyboard.prototype, '_relayout',
-      originalMethod => {
+      _ => {
         return function (...args) {
           let monitor = Main.layoutManager.keyboardMonitor;
           if (!monitor) return;
           this.width = monitor.width;
           if (monitor.width > monitor.height) {
             this.height = (monitor.height *
-                           settings.get_int("landscape-height")) / 100;
+              settings.get_int("landscape-height")) / 100;
           } else {
             this.height = (monitor.height *
-                           settings.get_int("portrait-height")) / 100;
+              settings.get_int("portrait-height")) / 100;
           }
 
           if (settings.get_boolean("show-suggestions")) {
@@ -297,7 +199,7 @@ export default class enhancedosk extends Extension {
 
     this._injectionManager.overrideMethod(
       Keyboard.KeyboardManager.prototype, '_lastDeviceIsTouchscreen',
-      originalMethod => {
+      _ => {
         return function (...args) {
           if (!this._lastDevice)
             return false;
@@ -312,8 +214,8 @@ export default class enhancedosk extends Extension {
     this._injectionManager.overrideMethod(
       Keyboard.Keyboard.prototype, '_init',
       originalMethod => {
-        return function (...args) {
-          originalMethod.call(this, ...args);
+        return function () {
+          originalMethod.call(this);
           this._keyboardController.getCurrentGroup = override_getCurrentGroup;
         }
       });
@@ -321,23 +223,20 @@ export default class enhancedosk extends Extension {
     this._injectionManager.overrideMethod(
       Keyboard.Keyboard.prototype, '_setupKeyboard',
       originalMethod => {
-        return function (...args) {
-          originalMethod.call(this, ...args);
+        return function () {
+          originalMethod.call(this);
           //track active level
-          this._activelayer = 0;
-          //track capslock
-          this._iscapslock = false;
+          this._activeLevel = 'default';
         }
       });
 
     this._injectionManager.overrideMethod(
-      Keyboard.Keyboard.prototype, '_setActiveLayer',
-      originalMethod => {
+      Keyboard.Keyboard.prototype, '_setActiveLevel',
+      _ => {
         return function (activeLevel) {
-          let activeGroupName = this._keyboardController.getCurrentGroup();
-          let layers = this._groups[activeGroupName];
+          const layers = this._layers;
           let currentPage = layers[activeLevel];
-          
+
           if (this._currentPage === currentPage) {
             this._updateCurrentPageVisible();
             return;
@@ -350,6 +249,7 @@ export default class enhancedosk extends Extension {
             delete this._currentPage._destroyID;
           }
 
+          this._disableAllModifiers();
           this._currentPage = currentPage;
           this._currentPage._destroyID = this._currentPage.connect('destroy', () => {
             this._currentPage = null;
@@ -358,18 +258,7 @@ export default class enhancedosk extends Extension {
           this._aspectContainer.setRatio(...this._currentPage.getRatio());
           this._emojiSelection.setRatio(...this._currentPage.getRatio());
           //track the active level
-          this._activelayer = activeLevel;
-        }
-      });
-
-    this._injectionManager.overrideMethod(
-      Keyboard.Keyboard.prototype, '_ensureKeysForGroup',
-      originalMethod => {
-        return function (group) {
-          if (!this._groups[group]){
-            this._groups[group] = this._createLayersForGroup(group);
-            addition_createLayersforGroup(this,group);
-          }
+          this._activeLevel = activeLevel;
         }
       });
 
@@ -377,79 +266,33 @@ export default class enhancedosk extends Extension {
     //action: modifier
     this._injectionManager.overrideMethod(
       Keyboard.Keyboard.prototype, '_toggleModifier',
-      originalMethod => {
+      _ => {
         return function (keyval) {
           const isActive = this._modifiers.has(keyval);
           const SHIFT_KEYVAL = '0xffe1';
-          if (keyval === SHIFT_KEYVAL){
+          if (keyval === SHIFT_KEYVAL) {
             //if capslock on just go back to layer 0
             //and do not activate modifier
-            if (this._iscapslock){
+            if (this._longPressed) {
               this._setLatched(false);
-              this._setActiveLayer(0);
-              this._iscapslock = false;
+              this._setActiveLevel('default');
+              this._longPressed = false;
               this._disableAllModifiers();
             }
             //otherwise switch between layers
-            else{
-              if (this._activelayer == 1){
-                this._setActiveLayer(0)}
-              else{
-                this._setActiveLayer(1);
+            else {
+              if (this._activeLevel == 'shift') {
+                this._setActiveLevel('default')
+              }
+              else {
+                this._setActiveLevel('shift');
               }
               this._setModifierEnabled(keyval, !isActive);
             }
           }
-          else{
+          else {
             this._setModifierEnabled(keyval, !isActive);
           };
-        }
-      });
-
-    this._injectionManager.overrideMethod(
-      Keyboard.Keyboard.prototype, '_commitAction',
-      originalMethod => {
-        return async function (keyval,str) {
-          if (this._modifiers.size === 0 && str !== '' &&
-              keyval && this._oskCompletionEnabled) {
-            if (await Main.inputMethod.handleVirtualKey(keyval))
-              return;
-          }
-
-          if (str === '' || !Main.inputMethod.currentFocus ||
-              (keyval && this._oskCompletionEnabled) ||
-              this._modifiers.size > 0 ||
-              !this._keyboardController.commitString(str, true)) {
-            if (keyval !== 0) {
-              this._forwardModifiers(this._modifiers, Clutter.EventType.KEY_PRESS);
-              this._keyboardController.keyvalPress(keyval);
-              keyReleaseTimeoutId = GLib.timeout_add(GLib.PRIORITY_DEFAULT, KEY_RELEASE_TIMEOUT, () => {
-                this._keyboardController.keyvalRelease(keyval);
-                this._forwardModifiers(this._modifiers, Clutter.EventType.KEY_RELEASE);
-                //override start
-                if (!this._iscapslock)
-                  this._disableAllModifiers();
-                //override end
-                return GLib.SOURCE_REMOVE;
-              });
-            }
-          }
-        }
-      })
-
-    this._injectionManager.overrideMethod(
-      Keyboard.Keyboard.prototype, '_toggleDelete',
-      originalMethod => {
-        return function (enabled) {
-          if (this._deleteEnabled === enabled) return;
-
-          this._deleteEnabled = enabled;
-
-          if (enabled) {
-            this._keyboardController.keyvalPress(Clutter.KEY_BackSpace);
-          } else {
-            this._keyboardController.keyvalRelease(Clutter.KEY_BackSpace);
-          }
         }
       });
 
@@ -457,7 +300,7 @@ export default class enhancedosk extends Extension {
     this.getDefaultLayouts()._unregister();
 
     // Register modified osk layouts resource file
-  this.getModifiedLayouts()._register();
+    this.getModifiedLayouts()._register();
   }
 
   disable_overrides() {
@@ -474,7 +317,7 @@ export default class enhancedosk extends Extension {
   getDefaultLayouts() {
     return Gio.Resource.load(
       (GLib.getenv("JHBUILD_PREFIX") || "/usr") +
-        "/share/gnome-shell/gnome-shell-osk-layouts.gresource"
+      "/share/gnome-shell/gnome-shell-osk-layouts.gresource"
     );
   }
 

--- a/src/metadata.json
+++ b/src/metadata.json
@@ -2,7 +2,7 @@
   "description": "Makes Gnome's OnScreen Keyboard more usable.\n\nFeatures:\n* Includes additional buttons: Arrow keys, Esc, Tab, Ctrl, Alt, Super, F1-12\n* Supports key combinations like `Ctrl + C`, `Alt + Tab`, `Ctrl + Shift + C`, `Super + A, Alt + F2` etc.\n* Configurable keyboard size (landscape/portrait)\n* Statusbar indicator to toggle keyboard\n* Works in Gnome password modals\n\nThis extension is a fork of https://github.com/nick-shmyrev/improved-osk-gnome-ext. Formerly known as Improved OSK.",
   "name": "Enhanced OSK",
   "shell-version": [
-    "45"
+    "46"
   ],
   "url": "https://github.com/cass00/enhanced-osk-gnome-ext",
   "uuid": "enhancedosk@cass00.github.io"


### PR DESCRIPTION
Addresses #14 

- Updated all osk layouts to use strings for levels instead of numbers
- Updated code wherever needed to address internal API changes to `ui/keyboard.js`
- Removed logic for caps_lock on long press shift as this is now default behavior in Gnome 46

As this is a breaking change to the extension and will only work on Gnome 46 I'm not sure how you want to proceed. Should there be a separate release branch for this new version or how do you usually handle backwards compatibility?